### PR TITLE
Fix: component type empty error

### DIFF
--- a/extensions/vscode-create-rax/CHANGELOG.md
+++ b/extensions/vscode-create-rax/CHANGELOG.md
@@ -1,17 +1,24 @@
 # Change Log
 
-## 0.0.1
+## 0.1.1
+- Add componentType option.
 
-- Add new project;
+## 0.1.0
+
+- Update rax-generator version from `^0.1.0` to `^1.0.2`;
+## 0.0.3
+
+- Add compatibility with react;
 
 ## 0.0.2
 
 - Refactor client;
 
-## 0.0.3
+## 0.0.1
 
-- Add compatibility with react;
+- Add new project;
 
-## 0.1.0
 
-- Update rax-generator version from `^0.1.0` to `^1.0.2`;
+
+
+

--- a/extensions/vscode-create-rax/client/src/pages/Create/Form/ComponentType.css
+++ b/extensions/vscode-create-rax/client/src/pages/Create/Form/ComponentType.css
@@ -1,0 +1,73 @@
+.componentType {
+  display: flex;
+  flex-wrap: wrap;
+}
+
+.componentTypeTitle {
+  position: relative;
+  width: 100%;
+  height: 20px;
+  font-size: 14px;
+  color: #A6A5AA;
+  font-weight: 600;
+}
+
+.componentTypeSelectedItemTag {
+  display: none;
+  position: absolute;
+  top: 7px;
+  right: 5px;
+  width: 16px;
+  height: 16px;
+}
+
+.componentTypeSelectedItem .componentTypeSelectedItemTag {
+  display: block;
+}
+
+.componentTypeItem {
+  padding-left: 5px;
+  margin: 10px 5px 10px 0;
+  border-radius: 2px;
+  position: relative;
+  display: flex;
+  flex-direction: column;
+  justify-content: center;
+  align-items: baseline;
+  width: 125px;
+  height: 30px;
+  cursor: pointer;
+}
+
+.componentTypeSelectedItem, .componentTypeItem:hover {
+  background-color: #333238;
+}
+
+.componentTypeItem:hover .componentTypeItemDescription {
+  display: block;
+}
+
+.componentTypeItemIcon {
+  width: 36px;
+  height: 36px;
+}
+
+.componentTypeItemTitle {
+  text-align: center;
+  font-size: 12px;
+  color: #979797;
+  user-select: none;
+}
+
+.componentTypeItemDescription {
+  display: none;
+  position: absolute;
+  bottom: 35px;
+  left: -60px;
+  width: 202px;
+  border: 1px solid #2B2B30;
+  background-color: #1e1e1e;
+  color: #979797;
+  font-size: 12px;
+  padding: 5px;
+}

--- a/extensions/vscode-create-rax/client/src/pages/Create/Form/ComponentType.js
+++ b/extensions/vscode-create-rax/client/src/pages/Create/Form/ComponentType.js
@@ -1,0 +1,50 @@
+import { createElement, forwardRef, useEffect, useImperativeHandle, useState } from 'rax';
+import isEnLang from '../isEnLang';
+import ComponentTypeOptions from '../configs/componentType';
+
+import './ComponentType.css';
+
+function ComponentType(props, ref) {
+  const [componentType, setComponentType] = useState('base');
+
+  function handleClick(options) {
+    setComponentType(options.type);
+  };
+
+  useImperativeHandle(ref, () => ({
+    getData: () => {
+      const res = { componentType };
+      return res;
+    }
+  }));
+
+  return (
+    <div className="componentType">
+      <p className="componentTypeTitle">
+        {isEnLang ?
+          "What's your component type?" :
+          '请选择组件类型'
+        }
+      </p>
+      {ComponentTypeOptions.map((option, index) => {
+        return (
+          <div
+            key={`option_${index}`}
+            onClick={() => {
+              handleClick(option);
+            }}
+            className={`componentTypeItem${componentType === option.type ? ' componentTypeSelectedItem' : ''} `}
+          >
+            <p className="componentTypeItemTitle">{isEnLang ? option.title_en : option.title}</p>
+            <img className="componentTypeSelectedItemTag" src="https://gw.alicdn.com/tfs/TB15rQzexD1gK0jSZFsXXbldVXa-200-200.svg" />
+            <div className="componentTypeItemDescription">
+              {isEnLang ? option.description_en : option.description}
+            </div>
+          </div>
+        );
+      })}
+    </div>
+  );
+};
+
+export default forwardRef(ComponentType);

--- a/extensions/vscode-create-rax/client/src/pages/Create/Form/index.js
+++ b/extensions/vscode-create-rax/client/src/pages/Create/Form/index.js
@@ -2,6 +2,7 @@ import { Fragment, createElement, useRef, useEffect, useState } from 'rax';
 import isEnLang from '../isEnLang';
 import Platforms from './Platforms';
 import AppType from './appType';
+import ComponentType from './ComponentType';
 import Features from './Features';
 
 import './index.css';
@@ -19,6 +20,7 @@ export default function Form(props) {
 
   const platformsRef = useRef(null);
   const featuresRef = useRef(null);
+  const componentTypeRef = useRef(null);
 
   // when type is app, show project features
   function featuresOptionToggle(targets) {
@@ -43,7 +45,8 @@ export default function Form(props) {
         Object.assign(
           res,
           platformsData,
-          showFeaturesOption ? featuresRef.current.getData() : {}
+          showFeaturesOption ? featuresRef.current.getData() : {},
+          type === 'component' ? componentTypeRef.current.getData() : {}
         );
         break;
       default:
@@ -84,6 +87,10 @@ export default function Form(props) {
         appType={appType}
         projectTargets={projectTargets}
         ref={featuresRef}
+      />
+      <ComponentType
+        x-if={type === 'component'}
+        ref={componentTypeRef}
       />
       <div className="footer">
         <a

--- a/extensions/vscode-create-rax/client/src/pages/Create/configs/componentType.js
+++ b/extensions/vscode-create-rax/client/src/pages/Create/configs/componentType.js
@@ -1,0 +1,26 @@
+import { createElement } from 'rax';
+
+export default [
+  {
+    type: 'base',
+    title: '基础组件',
+    title_en: 'Base Component',
+    description: (
+      <p>支持小程序的基础组件</p>
+    ),
+    description_en: (
+      <p>A simple component which can support MiniApp</p>
+    )
+  },
+  {
+    type: 'ui',
+    title: 'UI 组件',
+    title_en: 'UI Component',
+    description: (
+      <p>包含样式主题的 UI 组件</p>
+    ),
+    description_en: (
+      <p>A UI component which contains multi-theme solution</p>
+    )
+  }
+];

--- a/extensions/vscode-create-rax/package.json
+++ b/extensions/vscode-create-rax/package.json
@@ -3,7 +3,7 @@
   "displayName": "Create Rax",
   "description": "Easily create a new Rax project.",
   "publisher": "Rax",
-  "version": "0.1.0",
+  "version": "0.1.1",
   "engines": {
     "vscode": "^1.40.0"
   },


### PR DESCRIPTION
rax-generator@0.1.3 add new config `componentType` to init component. 

Create Rax use rax-generator@1.0.2. This PR add `componentType` option.